### PR TITLE
Repl/time off syncing fix

### DIFF
--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Common/UsersHelper.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Common/UsersHelper.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.ApplicationInsights;
+using Microsoft.Teams.Shifts.Integration.BusinessLogic.Models;
+using Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Teams.Shifts.Integration.API.Common
+{
+    /// <summary>
+    /// Provides utility methods for working with users.
+    /// </summary>
+    internal static class UsersHelper
+    {
+        /// <summary>
+        /// Get All mapped users, combining user and teams department mapping data.
+        /// </summary>
+        /// <param name="workForceIntegrationId">The workforce integration to get the users for.</param>
+        /// <param name="userMappingProvider">The user mapping provider.</param>
+        /// <param name="teamDepartmentMappingProvider">The team department mapping provider.</param>
+        /// <param name="telemetryClient">The telemetry client for logging.</param>
+        /// <returns>The full list of users.</returns>
+        internal static async Task<IEnumerable<UserDetailsModel>> GetAllMappedUserDetailsAsync(string workForceIntegrationId, IUserMappingProvider userMappingProvider, ITeamDepartmentMappingProvider teamDepartmentMappingProvider, TelemetryClient telemetryClient)
+        {
+            Dictionary<string, TeamToDepartmentJobMappingEntity> teamMappingEntities = new Dictionary<string, TeamToDepartmentJobMappingEntity>();
+            List<UserDetailsModel> kronosUsers = new List<UserDetailsModel>();
+
+            List<AllUserMappingEntity> mappedUsersResult = await userMappingProvider.GetAllMappedUserDetailsAsync().ConfigureAwait(false);
+
+            foreach (var element in mappedUsersResult)
+            {
+                TeamToDepartmentJobMappingEntity teamMappingEntity;
+                var key = $"{workForceIntegrationId}_{element.PartitionKey}";
+                if (teamMappingEntities.ContainsKey(key))
+                {
+                    teamMappingEntity = teamMappingEntities[key];
+                }
+                else
+                {
+                    teamMappingEntity = await teamDepartmentMappingProvider.GetTeamMappingForOrgJobPathAsync(
+                        workForceIntegrationId, element.PartitionKey).ConfigureAwait(false);
+                    if (teamMappingEntity == null)
+                    {
+                        telemetryClient.TrackTrace($"Team {element.PartitionKey} not mapped.");
+                        continue;
+                    }
+
+                    teamMappingEntities.Add(key, teamMappingEntity);
+                }
+
+                kronosUsers.Add(new UserDetailsModel
+                {
+                    KronosPersonNumber = element.RowKey,
+                    ShiftUserId = element.ShiftUserAadObjectId,
+                    ShiftTeamId = teamMappingEntity.TeamId,
+                    ShiftScheduleGroupId = teamMappingEntity.TeamsScheduleGroupId,
+                    OrgJobPath = element.PartitionKey,
+                    ShiftUserDisplayName = element.ShiftUserDisplayName,
+                    KronosTimeZone = teamMappingEntity.KronosTimeZone,
+                });
+            }
+
+            return kronosUsers;
+        }
+    }
+}

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TimeOffRequestsController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TimeOffRequestsController.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                 TimeOffRequestResponse.TimeOffRequestRes timeOffRequestContent = default(TimeOffRequestResponse.TimeOffRequestRes);
 
                 // Get the mapped user details from user to user mapping table.
-                var allUsers = await this.GetAllMappedUserDetailsAsync(allRequiredConfigurations.WFIId).ConfigureAwait(false);
+                var allUsers = await UsersHelper.GetAllMappedUserDetailsAsync(allRequiredConfigurations.WFIId, this.userMappingProvider, this.teamDepartmentMappingProvider, this.telemetryClient).ConfigureAwait(false);
 
                 // Get distinct Teams.
                 var allteamDetails = allUsers?.Select(x => x.ShiftTeamId).Distinct().ToList();
@@ -274,41 +274,6 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
         private async void AddorUpdateTimeOffMappingAsync(TimeOffMappingEntity timeOffMappingEntity)
         {
             await this.azureTableStorageHelper.InsertOrMergeTableEntityAsync(timeOffMappingEntity, "TimeOffMapping").ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Get All users for time off.
-        /// </summary>
-        /// <returns>A task.</returns>
-        private async Task<IEnumerable<UserDetailsModel>> GetAllMappedUserDetailsAsync(
-            string workForceIntegrationId)
-        {
-            List<UserDetailsModel> kronosUsers = new List<UserDetailsModel>();
-
-            List<AllUserMappingEntity> mappedUsersResult = await this.userMappingProvider.GetAllMappedUserDetailsAsync().ConfigureAwait(false);
-
-            foreach (var element in mappedUsersResult)
-            {
-                var teamMappingEntity = await this.teamDepartmentMappingProvider.GetTeamMappingForOrgJobPathAsync(
-                    workForceIntegrationId,
-                    element.PartitionKey).ConfigureAwait(false);
-
-                // If team department mapping for a user not present. Skip the user.
-                if (teamMappingEntity != null)
-                {
-                    kronosUsers.Add(new UserDetailsModel
-                    {
-                        KronosPersonNumber = element.RowKey,
-                        ShiftUserId = element.ShiftUserAadObjectId,
-                        ShiftTeamId = teamMappingEntity.TeamId,
-                        ShiftScheduleGroupId = teamMappingEntity.TeamsScheduleGroupId,
-                        OrgJobPath = element.PartitionKey,
-                        ShiftUserDisplayName = element.ShiftUserDisplayName,
-                    });
-                }
-            }
-
-            return kronosUsers;
         }
     }
 }

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Microsoft.Teams.Shifts.Integration.API.xml
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Microsoft.Teams.Shifts.Integration.API.xml
@@ -432,6 +432,21 @@
             <param name="secretValue">The actual value of the secret.</param>
             <returns>A unit of execution which has a string value boxed in.</returns>
         </member>
+        <member name="T:Microsoft.Teams.Shifts.Integration.API.Common.UsersHelper">
+            <summary>
+            Provides utility methods for working with users.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Teams.Shifts.Integration.API.Common.UsersHelper.GetAllMappedUserDetailsAsync(System.String,Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers.IUserMappingProvider,Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers.ITeamDepartmentMappingProvider,Microsoft.ApplicationInsights.TelemetryClient)">
+            <summary>
+            Get All mapped users, combining user and teams department mapping data.
+            </summary>
+            <param name="workForceIntegrationId">The workforce integration to get the users for.</param>
+            <param name="userMappingProvider">The user mapping provider.</param>
+            <param name="teamDepartmentMappingProvider">The team department mapping provider.</param>
+            <param name="telemetryClient">The telemetry client for logging.</param>
+            <returns>The full list of users.</returns>
+        </member>
         <member name="T:Microsoft.Teams.Shifts.Integration.API.Common.Utility">
             <summary>
             This is the utility class to perform several common operations such as Unique Id creation, Date Time operations, tokens fetch, session fecth, conditions checks etc.
@@ -1410,12 +1425,6 @@
             </summary>
             <param name="timeOffMappingEntity">The time off mapping entity to update or add.</param>
         </member>
-        <member name="M:Microsoft.Teams.Shifts.Integration.API.Controllers.TimeOffController.GetAllMappedUserDetailsAsync(System.String)">
-            <summary>
-            Get All users for time off.
-            </summary>
-            <returns>A task.</returns>
-        </member>
         <member name="T:Microsoft.Teams.Shifts.Integration.API.Controllers.TimeOffReasonController">
             <summary>
             Fetch TimeOffReasons from Kronos and create the same in Shifts.
@@ -1501,12 +1510,6 @@
             Method to either add or update the Time Off Entity Mapping.
             </summary>
             <param name="timeOffMappingEntity">A type of <see cref="T:Microsoft.Teams.Shifts.Integration.BusinessLogic.Models.TimeOffMappingEntity"/>.</param>
-        </member>
-        <member name="M:Microsoft.Teams.Shifts.Integration.API.Controllers.TimeOffRequestsController.GetAllMappedUserDetailsAsync(System.String)">
-            <summary>
-            Get All users for time off.
-            </summary>
-            <returns>A task.</returns>
         </member>
         <member name="T:Microsoft.Teams.Shifts.Integration.API.CustomAuthorize">
             <summary>


### PR DESCRIPTION
Refactored a common method used in two controllers into a single helper method and fixed an issue where the new KronosTimeZone was not being properly applied to the synced time off records.