### PR TITLE
repl/Handle nulls in response fix - part 2

### DIFF
--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Microsoft.Teams.Shifts.Integration.API.xml
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Microsoft.Teams.Shifts.Integration.API.xml
@@ -850,7 +850,7 @@
             Open Shift Requests controller.
             </summary>
         </member>
-        <member name="M:Microsoft.Teams.Shifts.Integration.API.Controllers.OpenShiftRequestController.#ctor(Microsoft.Teams.Shifts.Integration.API.Common.AppSettings,Microsoft.ApplicationInsights.TelemetryClient,Microsoft.Teams.App.KronosWfc.BusinessLogic.OpenShift.IOpenShiftActivity,Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers.IUserMappingProvider,Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers.ITeamDepartmentMappingProvider,Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers.IOpenShiftRequestMappingEntityProvider,System.Net.Http.IHttpClientFactory,Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers.IOpenShiftMappingEntityProvider,Microsoft.Teams.Shifts.Integration.API.Common.Utility,Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers.IShiftMappingEntityProvider,Microsoft.Teams.Shifts.Integration.API.Common.BackgroundTaskWrapper)">
+        <member name="M:Microsoft.Teams.Shifts.Integration.API.Controllers.OpenShiftRequestController.#ctor(Microsoft.Teams.Shifts.Integration.API.Common.AppSettings,Microsoft.ApplicationInsights.TelemetryClient,Microsoft.Teams.App.KronosWfc.BusinessLogic.OpenShift.IOpenShiftActivity,Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers.IUserMappingProvider,Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers.ITeamDepartmentMappingProvider,Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers.IOpenShiftRequestMappingEntityProvider,System.Net.Http.IHttpClientFactory,Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers.IOpenShiftMappingEntityProvider,Microsoft.Teams.Shifts.Integration.API.Common.Utility,Microsoft.Teams.Shifts.Integration.BusinessLogic.Providers.IShiftMappingEntityProvider)">
             <summary>
             Initializes a new instance of the <see cref="T:Microsoft.Teams.Shifts.Integration.API.Controllers.OpenShiftRequestController"/> class.
             </summary>
@@ -864,7 +864,6 @@
             <param name="openShiftMappingEntityProvider">The Open Shift Mapping DI.</param>
             <param name="utility">The common utility methods DI.</param>
             <param name="shiftMappingEntityProvider">Shift entity mapping provider DI.</param>
-            <param name="taskWrapper">Wrapper class instance for BackgroundTask.</param>
         </member>
         <member name="M:Microsoft.Teams.Shifts.Integration.API.Controllers.OpenShiftRequestController.SubmitOpenShiftRequestToKronosAsync(Microsoft.Teams.Shifts.Integration.API.Models.IntegrationAPI.OpenShiftRequestIS,System.String)">
             <summary>

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Startup.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Startup.cs
@@ -293,8 +293,7 @@ namespace Microsoft.Teams.Shifts.Integration.API
                 provider.GetRequiredService<IHttpClientFactory>(),
                 provider.GetRequiredService<IOpenShiftMappingEntityProvider>(),
                 provider.GetRequiredService<Utility>(),
-                provider.GetRequiredService<IShiftMappingEntityProvider>(),
-                provider.GetRequiredService<BackgroundTaskWrapper>()));
+                provider.GetRequiredService<IShiftMappingEntityProvider>()));
 
             services.AddSingleton((provider) => new TimeOffController(
                 provider.GetRequiredService<AppSettings>(),


### PR DESCRIPTION
Fix to build error - change of parameters for the OpenShiftRequestController was not updated in the Startup class.